### PR TITLE
TableViewCellの編集機能

### DIFF
--- a/DJYusaku.xcodeproj/project.pbxproj
+++ b/DJYusaku.xcodeproj/project.pbxproj
@@ -501,13 +501,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = J87XZSWPMZ;
+				DEVELOPMENT_TEAM = 29WP3DF4XR;
 				INFOPLIST_FILE = DJYusaku/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku.amylase;
+				PRODUCT_BUNDLE_IDENTIFIER = jp.yaplus.DJYusaku;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/DJYusaku/Base.lproj/Main.storyboard
+++ b/DJYusaku/Base.lproj/Main.storyboard
@@ -164,12 +164,12 @@
                         <viewLayoutGuide key="safeArea" id="PQr-Ze-W5v"/>
                     </view>
                     <navigationItem key="navigationItem" title="Requests" id="K0B-Hq-EiT">
-                        <barButtonItem key="leftBarButtonItem" title="Edit" id="9eT-eG-bit"/>
-                        <barButtonItem key="rightBarButtonItem" image="person.2.fill" catalog="system" id="u2n-sH-Den">
+                        <barButtonItem key="leftBarButtonItem" title="Session" id="u2n-sH-Den">
                             <connections>
-                                <segue destination="dBJ-r9-osw" kind="presentation" id="W7c-YK-Za5"/>
+                                <segue destination="dBJ-r9-osw" kind="presentation" id="Khf-ow-Fm0"/>
                             </connections>
                         </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Edit" id="9eT-eG-bit"/>
                     </navigationItem>
                     <connections>
                         <outlet property="playButton" destination="0xl-kp-iyr" id="bMD-w6-8IJ"/>
@@ -569,7 +569,6 @@
         <image name="forward.fill" catalog="system" width="64" height="38"/>
         <image name="magnifyingglass" catalog="system" width="64" height="56"/>
         <image name="music.note.list" catalog="system" width="64" height="56"/>
-        <image name="person.2.fill" catalog="system" width="64" height="40"/>
         <image name="play.fill" catalog="system" width="58" height="64"/>
         <image name="plus" catalog="system" width="64" height="56"/>
     </resources>

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -138,7 +138,7 @@ class PlayerQueue{
             // キュー中のアイテムを挿入->削除
             let descriptor = MPMusicPlayerStoreQueueDescriptor(storeIDs: [self.items[srcIndex].playbackStoreID])
             let afterIndex = dstIndex > srcIndex ? dstIndex : dstIndex-1
-            let afterItem  = afterIndex < 0      ? nil     : mutableQueue.items[afterIndex]
+            let afterItem  = afterIndex < 0      ? nil      : mutableQueue.items[afterIndex]
             mutableQueue.insert(descriptor, after: afterItem)
             mutableQueue.remove(mutableQueue.items[srcIndex])
         }, completionHandler: { [unowned self] queue, error in

--- a/DJYusaku/PlayerQueue.swift
+++ b/DJYusaku/PlayerQueue.swift
@@ -25,6 +25,7 @@ class PlayerQueue{
     private var isQueueCreated: Bool = false
     
     private let dispatchSemaphore = DispatchSemaphore(value: 1)
+    private let SEMAPHORE_TIMEOUT = 2.0
     
     private init(){
         mpAppController.repeatMode = MPMusicRepeatMode.all
@@ -41,7 +42,7 @@ class PlayerQueue{
     }
     
     private func create(with song : Song, completion: (() -> (Void))? = nil) {
-        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+        guard self.dispatchSemaphore.wait(timeout: .now() + SEMAPHORE_TIMEOUT) != .timedOut else {
             // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
             DispatchQueue.main.async {
                 guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
@@ -69,7 +70,7 @@ class PlayerQueue{
     }
 
     private func insert(after index: Int, with song : Song, completion: (() -> (Void))? = nil){
-        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+        guard self.dispatchSemaphore.wait(timeout: .now() + SEMAPHORE_TIMEOUT) != .timedOut else {
             // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
             DispatchQueue.main.async {
                 guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
@@ -96,7 +97,7 @@ class PlayerQueue{
     }
     
     func remove(at index: Int, completion: (() -> (Void))? = nil) {
-        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+        guard self.dispatchSemaphore.wait(timeout: .now() + SEMAPHORE_TIMEOUT) != .timedOut else {
             // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
             DispatchQueue.main.async {
                 guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
@@ -120,44 +121,34 @@ class PlayerQueue{
         })
     }
     
-    func swap(from: Int, to: Int, completion: (() -> (Void))? = nil){
+    func move(from srcIndex: Int, to dstIndex: Int, completion: (() -> (Void))? = nil){
         
-        let swappedItem = items[from]
-        guard self.dispatchSemaphore.wait(timeout: .now() + 4.0) != .timedOut else {
+        guard self.dispatchSemaphore.wait(timeout: .now() + SEMAPHORE_TIMEOUT) != .timedOut else {
             // 前のキューへの追加処理が時間内に終わっていなければとりあえずリクエストを捨てる
             DispatchQueue.main.async {
                 guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
-                let alert = UIAlertController(title: "Swap failed", message: "Swap failed. Try again.", preferredStyle: UIAlertController.Style.alert)
+                let alert = UIAlertController(title: "Move failed", message: "Swap failed. Try again.", preferredStyle: UIAlertController.Style.alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                 rootViewController.present(alert, animated: true)
             }
             return
         }
         
-        // 対象リクエストの削除->再挿入
         self.mpAppController.perform(queueTransaction: {[unowned self] mutableQueue in
-            if(to - 1 < 0){ //キューの先頭にはいれないようにしてもらう
-                guard let rootViewController = (UIApplication.shared.windows.filter{$0.isKeyWindow}.first)?.rootViewController else { return }
-                let alert = UIAlertController(title: "Swap failed", message: "Cannot move item to head of queue.", preferredStyle: UIAlertController.Style.alert)
-                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-                rootViewController.present(alert, animated: true)
-            }else{
-                mutableQueue.remove(swappedItem)
-                let mediaItemCollection = MPMediaItemCollection(items: [swappedItem])
-                let descriptor = MPMusicPlayerMediaItemQueueDescriptor(itemCollection: mediaItemCollection)
-                let insertItem = mutableQueue.items[to - 1]
-                print("insert after: " ,to-1)
-                mutableQueue.insert(descriptor, after: insertItem)
-            }
-
+            // キュー中のアイテムを挿入->削除
+            let descriptor = MPMusicPlayerStoreQueueDescriptor(storeIDs: [self.items[srcIndex].playbackStoreID])
+            let afterIndex = dstIndex > srcIndex ? dstIndex : dstIndex-1
+            let afterItem  = afterIndex < 0      ? nil     : mutableQueue.items[afterIndex]
+            mutableQueue.insert(descriptor, after: afterItem)
+            mutableQueue.remove(mutableQueue.items[srcIndex])
         }, completionHandler: { [unowned self] queue, error in
             defer {
                 self.dispatchSemaphore.signal()
             }
             guard (error == nil) else { return } // TODO: 挿入ができなかった時の処理
-                self.items = queue.items
-                if let completion = completion { completion() }
-                NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
+            self.items = queue.items
+            if let completion = completion { completion() }
+            NotificationCenter.default.post(name: .DJYusakuPlayerQueueDidUpdate, object: nil)
         })
     }
     

--- a/DJYusaku/RequestsViewController.swift
+++ b/DJYusaku/RequestsViewController.swift
@@ -48,7 +48,7 @@ class RequestsViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleNowPlayingItemDidChange), name: .DJYusakuPlayerQueueNowPlayingSongDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handlePlaybackStateDidChange), name: .DJYusakuPlayerQueuePlaybackStateDidChange, object: nil)
         
-        navigationItem.leftBarButtonItem = editButtonItem
+        navigationItem.rightBarButtonItem = editButtonItem
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -146,7 +146,7 @@ extension RequestsViewController: UITableViewDataSource {
     // 編集時の動作
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         if(ConnectionController.shared.isParent){ //自分がDJのとき
-            PlayerQueue.shared.swap(from: sourceIndexPath.row, to: destinationIndexPath.row)
+            PlayerQueue.shared.move(from: sourceIndexPath.row, to: destinationIndexPath.row)
         }else{
             // TODO: リスナー側の動作
         }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 「DJ YUSAKU」はその場のみんなで簡単にプレイリストを作って再生できる革新的なアプリケーションです。  
 
 ## インストール
-**TestFlightを使ってDJ YUSAKU Appを一足先に試用することができます🎉**
+**TestFlightを使ってDJ YUSAKU Appを一足先に試用することができます✈️**
 1. 自分の学籍番号（あるいは受信可能なメールアドレス）をenPiTの [#team_優作](https://app.slack.com/client/THHKFQY3H/CM236RA8G) の **[この投稿](https://enpit2019tkb.slack.com/archives/CM236RA8G/p1573648358002600)** に書き込んでください。  
 [@yaplus](https://github.com/yaplus) が確認して、 s(自分の学籍番号)@s.tsukuba.ac.jp （あるいは教えていただいたメールアドレス）をテスターとしてApp Store Connectに登録します。
 2. App Storeから [TestFlight](https://apps.apple.com/jp/app/testflight/id899247664) をインストールします。TestFlight にApple IDでログインを行ってください。

--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@
 
 「DJ YUSAKU」はその場のみんなで簡単にプレイリストを作って再生できる革新的なアプリケーションです。  
 
+#### 対応デバイス
+
+- iOS 13以降を搭載したiPhone/iPod touch
+- iPadOS 13以降を搭載したiPad
+
+DJとしてのセッション参加にはApple Musicのメンバーシップが必要です。
+
 ## インストール
+
 **TestFlightを使ってDJ YUSAKU Appを一足先に試用することができます✈️**
 1. 自分の学籍番号（あるいは受信可能なメールアドレス）をenPiTの [#team_優作](https://app.slack.com/client/THHKFQY3H/CM236RA8G) の **[この投稿](https://enpit2019tkb.slack.com/archives/CM236RA8G/p1573648358002600)** に書き込んでください。  
 [@yaplus](https://github.com/yaplus) が確認して、 s(自分の学籍番号)@s.tsukuba.ac.jp （あるいは教えていただいたメールアドレス）をテスターとしてApp Store Connectに登録します。
-2. App Storeから [TestFlight](https://apps.apple.com/jp/app/testflight/id899247664) をインストールします。TestFlight にApple IDでログインを行ってください。
+2. App Storeから [TestFlight](https://apps.apple.com/jp/app/testflight/id899247664) をインストールします。TestFlight にApple IDでログインを行ってください。  
+（Apple IDの登録メールアドレスは上で教えていただいたメールアドレスと同じである必要はありません。）
 3. 1.でテスター登録したメールアドレス宛に届いているメールに、アプリケーションのインストールに必要なリンクが添付されています。  
 メール内の「View in TestFlight」をタップすると、TestFlightでアプリケーションのインストールを行うことができます。
 


### PR DESCRIPTION
performのだいたい中身を修正することになったけど、これでちゃんと動くはず

### 主な変更点

- 関数名を `swap` -> `move` に
  - TableViewDelegateの名前からしてもswapではないだろう…
- `move` の中身をほぼ書き直し
  - Descripterの生成にSongIDを引っ張ってくるようにした
  - 移動元と移動先の関係によって妙な挙動があるようだったので対策
  - キューの先頭が移動先だった時は適当に処理した（エラーは出してない）
    - もちろんキューの先頭が移動元だった時は問題なし
- Editボタンの位置変更
  - 標準アプリはEditが右上にあるため、前々から直したいと思っていた